### PR TITLE
Add plugin support for Helm chart

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Rico Berger
+Copyright (c) 2021 Rico Berger
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/dashboards/cert-manager-dashboard.yaml
+++ b/dashboards/cert-manager-dashboard.yaml
@@ -9,6 +9,21 @@ metadata:
 data:
   title: "cert-manager"
   description: "Dashboard for cert-manager Metrics"
+  variables: |
+    [
+      {
+        "name": "Namespace",
+        "label": "exported_namespace",
+        "query": "certmanager_certificate_expiration_timestamp_seconds",
+        "allowAll": true
+      },
+      {
+        "name": "Name",
+        "label": "name",
+        "query": "certmanager_certificate_expiration_timestamp_seconds{exported_namespace=~\"{{ .Namespace }}\"}",
+        "allowAll": true
+      }
+    ]
   charts: |
     [
       {
@@ -25,7 +40,7 @@ data:
         "queries": [
           {
             "label": " {{ .exported_namespace }} / {{ .name }}",
-            "query": "(sum(certmanager_certificate_expiration_timestamp_seconds - time()) by (name,exported_namespace)) / 60 / 60 / 24"
+            "query": "(sum(certmanager_certificate_expiration_timestamp_seconds{exported_namespace=~\"{{ .Namespace }}\", name=~\"{{ .Name }}\"} - time()) by (name,exported_namespace)) / 60 / 60 / 24"
           }
         ]
       },
@@ -43,7 +58,7 @@ data:
         "queries": [
           {
             "label": "{{ .condition }}",
-            "query": "sum(certmanager_certificate_ready_status) by (condition)"
+            "query": "sum(certmanager_certificate_ready_status{exported_namespace=~\"{{ .Namespace }}\", name=~\"{{ .Name }}\"}) by (condition)"
           }
         ]
       },

--- a/dashboards/jvm-dashboard.yaml
+++ b/dashboards/jvm-dashboard.yaml
@@ -27,8 +27,8 @@ data:
   charts: |
     [
       {
-        "title": "Classes Loading Rate",
-        "unit": "",
+        "title": "Memory Usage",
+        "unit": "MiB",
         "size": {
           "xs": "12",
           "sm": "12",
@@ -39,8 +39,80 @@ data:
         "type": "area",
         "queries": [
           {
-            "label": "Class Loading Rate",
-            "query": "rate(jvm_classes_loaded{namespace=\"{{ .Namespace }}\", pod=\"{{ .Pod }}\"}[1m])"
+            "label": "Memory Usage",
+            "query": "sum(container_memory_usage_bytes{namespace=\"{{ .Namespace }}\", pod=\"{{ .Pod }}\", container!=\"\", container!=\"POD\"}) / 1024 / 1024"
+          }
+        ]
+      },
+      {
+        "title": "CPU Usage",
+        "unit": "Cores",
+        "size": {
+          "xs": "12",
+          "sm": "12",
+          "md": "12",
+          "lg": "6",
+          "xl": "6"
+        },
+        "type": "area",
+        "queries": [
+          {
+            "label": "CP Usage",
+            "query": "sum(rate(container_cpu_user_seconds_total{namespace=\"{{ .Namespace }}\", pod=\"{{ .Pod }}\"}[1m]))"
+          }
+        ]
+      },
+      {
+        "title": "Memory Used",
+        "unit": "MiB",
+        "size": {
+          "xs": "12",
+          "sm": "12",
+          "md": "12",
+          "lg": "4",
+          "xl": "4"
+        },
+        "type": "area",
+        "queries": [
+          {
+            "label": "Memory Used",
+            "query": "sum(rate(jvm_memory_bytes_used{namespace=\"{{ .Namespace }}\", pod=\"{{ .Pod }}\"}[1m])) / 1024 / 1024"
+          }
+        ]
+      },
+      {
+        "title": "GC Time",
+        "unit": "s",
+        "size": {
+          "xs": "12",
+          "sm": "12",
+          "md": "12",
+          "lg": "4",
+          "xl": "4"
+        },
+        "type": "area",
+        "queries": [
+          {
+            "label": "{{ .gc }}",
+            "query": "sum(rate(jvm_gc_collection_seconds_sum{namespace=\"{{ .Namespace }}\", pod=\"{{ .Pod }}\"}[1m])) by (gc)"
+          }
+        ]
+      },
+      {
+        "title": "GC Count",
+        "unit": "",
+        "size": {
+          "xs": "12",
+          "sm": "12",
+          "md": "12",
+          "lg": "4",
+          "xl": "4"
+        },
+        "type": "area",
+        "queries": [
+          {
+            "label": "{{ .gc }}",
+            "query": "sum(rate(jvm_gc_collection_seconds_count{namespace=\"{{ .Namespace }}\", pod=\"{{ .Pod }}\"}[1m])) by (gc)"
           }
         ]
       },
@@ -57,121 +129,13 @@ data:
         "type": "area",
         "queries": [
           {
-            "label": "Total Loaded Classes",
-            "query": "jvm_classes_loaded{namespace=\"{{ .Namespace }}\", pod=\"{{ .Pod }}\"}"
+            "label": "Classes",
+            "query": "sum(jvm_classes_loaded{namespace=\"{{ .Namespace }}\", pod=\"{{ .Pod }}\"})"
           }
         ]
       },
       {
-        "title": "Garbage Collection Duration",
-        "unit": "s",
-        "size": {
-          "xs": "12",
-          "sm": "12",
-          "md": "12",
-          "lg": "6",
-          "xl": "6"
-        },
-        "type": "area",
-        "queries": [
-          {
-            "label": "{{ .gc }}",
-            "query": "rate(jvm_gc_collection_seconds_sum{namespace=\"{{ .Namespace }}\", pod=\"{{ .Pod }}\"}[1m])"
-          }
-        ]
-      },
-      {
-        "title": "Garbage Collection Operations",
-        "unit": "ops",
-        "size": {
-          "xs": "12",
-          "sm": "12",
-          "md": "12",
-          "lg": "6",
-          "xl": "6"
-        },
-        "type": "area",
-        "queries": [
-          {
-            "label": "{{ .gc }}",
-            "query": "rate(jvm_gc_collection_seconds_count{namespace=\"{{ .Namespace }}\", pod=\"{{ .Pod }}\"}[1m])"
-          }
-        ]
-      },
-      {
-        "title": "Memory Max.",
-        "unit": "MiB",
-        "size": {
-          "xs": "12",
-          "sm": "12",
-          "md": "12",
-          "lg": "6",
-          "xl": "6"
-        },
-        "type": "area",
-        "queries": [
-          {
-            "label": "{{ .area }}",
-            "query": "jvm_memory_bytes_max{namespace=\"{{ .Namespace }}\", pod=\"{{ .Pod }}\"} / 1024 / 1024"
-          }
-        ]
-      },
-      {
-        "title": "Memory Used",
-        "unit": "MiB",
-        "size": {
-          "xs": "12",
-          "sm": "12",
-          "md": "12",
-          "lg": "6",
-          "xl": "6"
-        },
-        "type": "area",
-        "queries": [
-          {
-            "label": "{{ .area }}",
-            "query": "jvm_memory_bytes_used{namespace=\"{{ .Namespace }}\", pod=\"{{ .Pod }}\"} / 1024 / 1024"
-          }
-        ]
-      },
-      {
-        "title": "Memory Pool Max.",
-        "unit": "MiB",
-        "size": {
-          "xs": "12",
-          "sm": "12",
-          "md": "12",
-          "lg": "6",
-          "xl": "6"
-        },
-        "type": "area",
-        "queries": [
-          {
-            "label": "{{ .pool }}",
-            "query": "jvm_memory_pool_bytes_max{namespace=\"{{ .Namespace }}\", pod=\"{{ .Pod }}\"} / 1024 / 1024"
-          }
-        ]
-      },
-      {
-        "title": "Memory Pool Used ",
-        "unit": "MiB",
-        "size": {
-          "xs": "12",
-          "sm": "12",
-          "md": "12",
-          "lg": "6",
-          "xl": "6"
-        },
-        "type": "area",
-        "queries": [
-          {
-            "label": "{{ .pool }}",
-            "query": "jvm_memory_pool_bytes_used{namespace=\"{{ .Namespace }}\", pod=\"{{ .Pod }}\"} / 1024 / 1024"
-          }
-        ]
-      },
-      {
-        "title": "Threads",
+        "title": "Thread Count",
         "unit": "",
         "size": {
           "xs": "12",
@@ -184,25 +148,7 @@ data:
         "queries": [
           {
             "label": "Threads",
-            "query": "jvm_threads_current{namespace=\"{{ .Namespace }}\", pod=\"{{ .Pod }}\"}"
-          }
-        ]
-      },
-      {
-        "title": "Threads Peak",
-        "unit": "",
-        "size": {
-          "xs": "12",
-          "sm": "12",
-          "md": "12",
-          "lg": "6",
-          "xl": "6"
-        },
-        "type": "area",
-        "queries": [
-          {
-            "label": "Threads Peak",
-            "query": "jvm_threads_peak{namespace=\"{{ .Namespace }}\", pod=\"{{ .Pod }}\"}"
+            "query": "sum(jvm_threads_current{namespace=\"{{ .Namespace }}\", pod=\"{{ .Pod }}\"})"
           }
         ]
       }

--- a/dashboards/strimzi-kafka-dashboard.yaml
+++ b/dashboards/strimzi-kafka-dashboard.yaml
@@ -32,13 +32,13 @@ data:
       {
         "name": "Topic",
         "label": "topic",
-        "query": "kafka_cluster_partition_replicascount{namespace=~\"{{ .Namespace }}\", strimzi_io_cluster=\"{{ .Cluster }}\", kubernetes_pod_name=~\"{{ .Cluster }}-{{ .Broker }}\"}",
+        "query": "kafka_cluster_partition_replicascount{namespace=~\"{{ .Namespace }}\", strimzi_io_cluster=\"{{ .Cluster }}\", kubernetes_pod_name=~\"{{ .Broker }}\"}",
         "allowAll": true
       },
       {
         "name": "Partition",
         "label": "partition",
-        "query": "kafka_log_log_size{namespace=~\"{{ .Namespace }}\", strimzi_io_cluster=\"{{ .Cluster }}\", kubernetes_pod_name=~\"{{ .Cluster }}-{{ .Broker }}\", topic=~\"{{ .Topic }}\"}",
+        "query": "kafka_log_log_size{namespace=~\"{{ .Namespace }}\", strimzi_io_cluster=\"{{ .Cluster }}\", kubernetes_pod_name=~\"{{ .Broker }}\", topic=~\"{{ .Topic }}\"}",
         "allowAll": true
       }
     ]
@@ -153,60 +153,6 @@ data:
         ]
       },
       {
-        "title": "JVM Memory Used",
-        "unit": "MiB",
-        "size": {
-          "xs": "12",
-          "sm": "12",
-          "md": "12",
-          "lg": "4",
-          "xl": "4"
-        },
-        "type": "area",
-        "queries": [
-          {
-            "label": "{{ .kubernetes_pod_name }}",
-            "query": "sum(rate(jvm_memory_bytes_used{namespace=~\"{{ .Namespace }}\",kubernetes_pod_name=~\"{{ .Cluster }}-{{ .Broker }}\",strimzi_io_name=\"{{ .Cluster }}-kafka\"}[5m])) by (kubernetes_pod_name) / 1024 / 1024"
-          }
-        ]
-      },
-      {
-        "title": "JVM GC Time",
-        "unit": "s",
-        "size": {
-          "xs": "12",
-          "sm": "12",
-          "md": "12",
-          "lg": "4",
-          "xl": "4"
-        },
-        "type": "area",
-        "queries": [
-          {
-            "label": "{{ .kubernetes_pod_name }}",
-            "query": "sum(rate(jvm_gc_collection_seconds_sum{namespace=~\"{{ .Namespace }}\",kubernetes_pod_name=~\"{{ .Cluster }}-{{ .Broker }}\",strimzi_io_name=\"{{ .Cluster }}-kafka\"}[5m])) by (kubernetes_pod_name)"
-          }
-        ]
-      },
-      {
-        "title": "JVM GC Count",
-        "unit": "",
-        "size": {
-          "xs": "12",
-          "sm": "12",
-          "md": "12",
-          "lg": "4",
-          "xl": "4"
-        },
-        "type": "area",
-        "queries": [
-          {
-            "label": "{{ .kubernetes_pod_name }}",
-            "query": "sum(rate(jvm_gc_collection_seconds_count{namespace=~\"{{ .Namespace }}\",kubernetes_pod_name=~\"{{ .Cluster }}-{{ .Broker }}\",strimzi_io_name=\"{{ .Cluster }}-kafka\"}[5m])) by (kubernetes_pod_name)"
-          }
-        ]
-      },
-      {
         "title": "Byte Rate",
         "unit": "B",
         "size": {
@@ -220,11 +166,11 @@ data:
         "queries": [
           {
             "label": "Total Incoming Byte Rate",
-            "query": "sum(irate(kafka_server_brokertopicmetrics_bytesin_total{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",topic=~\"{{ .Topic }}\",kubernetes_pod_name=~\"{{ .Cluster }}-{{ .Broker }}\"}[1m]))"
+            "query": "sum(irate(kafka_server_brokertopicmetrics_bytesin_total{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",topic=~\"{{ .Topic }}\",kubernetes_pod_name=~\"{{ .Broker }}\"}[1m]))"
           },
           {
             "label": "Total Outgoing Byte Rate",
-            "query": "sum(irate(kafka_server_brokertopicmetrics_bytesout_total{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",topic=~\"{{ .Topic }}\",kubernetes_pod_name=~\"{{ .Cluster }}-{{ .Broker }}\"}[1m]))"
+            "query": "sum(irate(kafka_server_brokertopicmetrics_bytesout_total{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",topic=~\"{{ .Topic }}\",kubernetes_pod_name=~\"{{ .Broker }}\"}[1m]))"
           }
         ]
       },
@@ -242,7 +188,7 @@ data:
         "queries": [
           {
             "label": "Total Message In Per Second",
-            "query": "sum(irate(kafka_server_brokertopicmetrics_messagesin_total{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",topic=~\"{{ .Topic }}\",kubernetes_pod_name=~\"{{ .Cluster }}-{{ .Broker }}\"}[1m]))"
+            "query": "sum(irate(kafka_server_brokertopicmetrics_messagesin_total{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",topic=~\"{{ .Topic }}\",kubernetes_pod_name=~\"{{ .Broker }}\"}[1m]))"
           }
         ]
       },
@@ -260,11 +206,11 @@ data:
         "queries": [
           {
             "label": "Total Produce Request Rate",
-            "query": "sum(irate(kafka_server_brokertopicmetrics_totalproducerequests_total{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",topic=~\"{{ .Topic }}\",kubernetes_pod_name=~\"{{ .Cluster }}-{{ .Broker }}\"}[1m]))"
+            "query": "sum(irate(kafka_server_brokertopicmetrics_totalproducerequests_total{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",topic=~\"{{ .Topic }}\",kubernetes_pod_name=~\"{{ .Broker }}\"}[1m]))"
           },
           {
             "label": "Failed Produce Request Rate",
-            "query": "sum(irate(kafka_server_brokertopicmetrics_failedproducerequests_total{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",topic=~\"{{ .Topic }}\",kubernetes_pod_name=~\"{{ .Cluster }}-{{ .Broker }}\"}[1m]))"
+            "query": "sum(irate(kafka_server_brokertopicmetrics_failedproducerequests_total{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",topic=~\"{{ .Topic }}\",kubernetes_pod_name=~\"{{ .Broker }}\"}[1m]))"
           }
         ]
       },
@@ -282,11 +228,11 @@ data:
         "queries": [
           {
             "label": "Fetch Request Rate",
-            "query": "sum(irate(kafka_server_brokertopicmetrics_totalfetchrequests_total{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",topic=~\"{{ .Topic }}\",kubernetes_pod_name=~\"{{ .Cluster }}-{{ .Broker }}\"}[1m]))"
+            "query": "sum(irate(kafka_server_brokertopicmetrics_totalfetchrequests_total{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",topic=~\"{{ .Topic }}\",kubernetes_pod_name=~\"{{ .Broker }}\"}[1m]))"
           },
           {
             "label": "Failed Fetch Request Rate",
-            "query": "sum(irate(kafka_server_brokertopicmetrics_failedfetchrequests_total{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",topic=~\"{{ .Topic }}\",kubernetes_pod_name=~\"{{ .Cluster }}-{{ .Broker }}\"}[1m]))"
+            "query": "sum(irate(kafka_server_brokertopicmetrics_failedfetchrequests_total{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",topic=~\"{{ .Topic }}\",kubernetes_pod_name=~\"{{ .Broker }}\"}[1m]))"
           }
         ]
       },
@@ -304,7 +250,7 @@ data:
         "queries": [
           {
             "label": "{{ .kubernetes_pod_name }}",
-            "query": "kafka_network_socketserver_networkprocessoravgidle_percent{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",kubernetes_pod_name=~\"{{ .Cluster }}-{{ .Broker }}\"}*100"
+            "query": "kafka_network_socketserver_networkprocessoravgidle_percent{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",kubernetes_pod_name=~\"{{ .Broker }}\"}*100"
           }
         ]
       },
@@ -322,7 +268,7 @@ data:
         "queries": [
           {
             "label": "{{ .kubernetes_pod_name }}",
-            "query": "kafka_server_kafkarequesthandlerpool_requesthandleravgidle_percent{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",kubernetes_pod_name=~\"{{ .Cluster }}-{{ .Broker }}\"}*100"
+            "query": "kafka_server_kafkarequesthandlerpool_requesthandleravgidle_percent{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",kubernetes_pod_name=~\"{{ .Broker }}\"}*100"
           }
         ]
       },
@@ -340,7 +286,7 @@ data:
         "queries": [
           {
             "label": "{{ .topic }}:{{ .partition }}",
-            "query": "kafka_log_log_size{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",kubernetes_pod_name=~\"{{ .Cluster }}-{{ .Broker }}\",topic=~\"{{ .Topic }}\",partition=~\"{{ .Partition }}\"}"
+            "query": "kafka_log_log_size{namespace=~\"{{ .Namespace }}\",strimzi_io_cluster=\"{{ .Cluster }}\",kubernetes_pod_name=~\"{{ .Broker }}\",topic=~\"{{ .Topic }}\",partition=~\"{{ .Partition }}\"}"
           }
         ]
       }

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kubenav
 description: kubenav is the navigator for your Kubernetes clusters right in your pocket.
 type: application
-version: 1.0.3
-appVersion: 3.2.0
+version: 1.1.0
+appVersion: 3.3.0

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -36,6 +36,58 @@ spec:
             {{- if .Values.plugins.prometheus.enabled }}
             - --plugin.prometheus.enabled
             - --plugin.prometheus.address={{ .Values.plugins.prometheus.address }}
+            - --plugin.prometheus.dashboards-namespace={{ .Values.plugins.prometheus.dashboardsNamespace }}
+            {{- end }}
+            {{- if .Values.plugins.elasticsearch.enabled }}
+            - --plugin.elasticsearch.enabled
+            - --plugin.elasticsearch.address={{ .Values.plugins.elasticsearch.address }}
+            {{- end }}
+            {{- if and (ne .Values.plugins.elasticsearch.username "") (ne .Values.plugins.elasticsearch.password "") }}
+            - --plugin.elasticsearch.username={{ .Values.plugins.elasticsearch.username }}
+            {{- end }}
+            {{- if .Values.plugins.jaeger.enabled }}
+            - --plugin.jaeger.enabled
+            - --plugin.jaeger.address={{ .Values.plugins.jaeger.address }}
+            {{- end }}
+            {{- if and (ne .Values.plugins.jaeger.username "") (ne .Values.plugins.jaeger.password "") }}
+            - --plugin.jaeger.username={{ .Values.plugins.jaeger.username }}
+            {{- end }}
+          env:
+            {{- if and (ne .Values.plugins.prometheus.username "") (ne .Values.plugins.prometheus.password "") }}
+            - name: KUBENAV_PROMETHEUS_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubenav.fullname" . }}-plugins
+                  key: KUBENAV_PROMETHEUS_USERNAME
+            - name: KUBENAV_PROMETHEUS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubenav.fullname" . }}-plugins
+                  key: KUBENAV_PROMETHEUS_PASSWORD
+            {{- end }}
+            {{- if and (ne .Values.plugins.elasticsearch.username "") (ne .Values.plugins.elasticsearch.password "") }}
+            - name: KUBENAV_ELASTICSEARCH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubenav.fullname" . }}-plugins
+                  key: KUBENAV_ELASTICSEARCH_USERNAME
+            - name: KUBENAV_ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubenav.fullname" . }}-plugins
+                  key: KUBENAV_ELASTICSEARCH_PASSWORD
+            {{- end }}
+            {{- if and (ne .Values.plugins.jaeger.username "") (ne .Values.plugins.jaeger.password "") }}
+            - name: KUBENAV_JAEGER_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubenav.fullname" . }}-plugins
+                  key: KUBENAV_JAEGER_USERNAME
+            - name: KUBENAV_JAEGER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubenav.fullname" . }}-plugins
+                  key: KUBENAV_JAEGER_PASSWORD
             {{- end }}
           ports:
             - name: http

--- a/helm/templates/secret-plugins.yaml
+++ b/helm/templates/secret-plugins.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kubenav.fullname" . }}-plugins
+  labels:
+    {{- include "kubenav.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if and (ne .Values.plugins.prometheus.username "") (ne .Values.plugins.prometheus.password "") }}
+  KUBENAV_PROMETHEUS_USERNAME: {{ .Values.plugins.prometheus.username | b64enc }}
+  KUBENAV_PROMETHEUS_PASSWORD: {{ .Values.plugins.prometheus.password | b64enc }}
+  {{- end }}
+  {{- if and (ne .Values.plugins.elasticsearch.username "") (ne .Values.plugins.elasticsearch.password "") }}
+  KUBENAV_ELASTICSEARCH_USERNAME: {{ .Values.plugins.elasticsearch.username | b64enc }}
+  KUBENAV_ELASTICSEARCH_PASSWORD: {{ .Values.plugins.elasticsearch.password | b64enc }}
+  {{- end }}
+  {{- if and (ne .Values.plugins.jaeger.username "") (ne .Values.plugins.jaeger.password "") }}
+  KUBENAV_JAEGER_USERNAME: {{ .Values.plugins.jaeger.username | b64enc }}
+  KUBENAV_JAEGER_PASSWORD: {{ .Values.plugins.jaeger.password | b64enc }}
+  {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 
 image:
   repository: kubenav/kubenav
-  tag: 3.2.0
+  tag: 3.3.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -19,9 +19,25 @@ deployment:
   kubeconfig:
 
 plugins:
+  # Settings for the Prometheus plugin: https://docs.kubenav.io/plugins/prometheus/
   prometheus:
     enabled: false
-    address:
+    address: "http://prometheus.monitoring.svc.cluster.local:9090"
+    username: ""
+    password: ""
+    dashboardsNamespace: kubenav
+  # Settings for the Elasticsearch plugin: https://docs.kubenav.io/plugins/elasticsearch/
+  elasticsearch:
+    enabled: false
+    address: "http://elasticsearch.logging.svc.cluster.local:9200"
+    username: ""
+    password: ""
+  # Settings for the Jaeger plugin: https://docs.kubenav.io/plugins/jaeger/
+  jaeger:
+    enabled: false
+    address: "http://jaeger-query.tracing.svc.cluster.local:16686"
+    username: ""
+    password: ""
 
 rbac:
   # Specifies whether a cluster role and cluster role binding should be created.

--- a/kustomize/deployment.yaml
+++ b/kustomize/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: kubenav
       containers:
         - name: kubenav
-          image: kubenav/kubenav:3.2.0
+          image: kubenav/kubenav:3.3.0
           imagePullPolicy: IfNotPresent
           args:
             - --incluster


### PR DESCRIPTION
The Helm chart can be now configured to enable the Prometheus, Elasticsearch and Jaeger plugin. It is also possible to configure the address, username and password for each plugin via the values.yaml file.